### PR TITLE
Remove hardcoded module paths.

### DIFF
--- a/groups/bluetooth/btusb/init.rc
+++ b/groups/bluetooth/btusb/init.rc
@@ -3,13 +3,6 @@ on post-fs-data
     mkdir /data/misc/hcid 0770 bluetooth bluetooth
 
 on boot
-    insmod ${ro.boot.moduleslocation}/iptable_raw.ko
-    insmod ${ro.boot.moduleslocation}/ip6table_raw.ko
-    insmod ${ro.boot.moduleslocation}/8250_dw.ko
-    insmod ${ro.boot.moduleslocation}/6lowpan_iphc.ko
-    insmod ${ro.boot.moduleslocation}/bluetooth.ko
-    insmod ${ro.boot.moduleslocation}/btusb.ko
-    insmod ${ro.boot.moduleslocation}/ath3k.ko
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 

--- a/groups/bluetooth/rtl8723bs/init.rc
+++ b/groups/bluetooth/rtl8723bs/init.rc
@@ -3,10 +3,6 @@
 #  BLUETOOTH CONFIGURATION - REALTEK SPECIFIC
 ########################################################
 on boot
-    insmod ${ro.boot.moduleslocation}/bt_lpm.ko
-    insmod ${ro.boot.moduleslocation}/iptable_raw.ko
-    insmod ${ro.boot.moduleslocation}/ip6table_raw.ko
-    insmod ${ro.boot.moduleslocation}/6lowpan_iphc.ko
     start rfkill_bt
 
 on post-fs
@@ -48,9 +44,6 @@ on post-fs-data
     mkdir /data/misc/hcid 0770 bluetooth bluetooth
 
 on boot
-    insmod ${ro.boot.moduleslocation}/8250_dw.ko
-    insmod ${ro.boot.moduleslocation}/bluetooth.ko
-    insmod ${ro.boot.moduleslocation}/hci_uart.ko
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_max_credits
     chmod 0644 /sys/kernel/debug/bluetooth/l2cap_le_default_mps
 
@@ -76,9 +69,4 @@ service dhcpcd_bt-pan /system/bin/dhcpcd -ABKL
 service iprenew_bt-pan /system/bin/dhcpcd -n
     disabled
     oneshot
-
-on boot
-    insmod ${ro.boot.moduleslocation}/iptable_raw.ko
-    insmod ${ro.boot.moduleslocation}/ip6table_raw.ko
-    insmod ${ro.boot.moduleslocation}/6lowpan_iphc.ko
 {{/hsu}}

--- a/groups/bluetooth/stonepeak/init.rc
+++ b/groups/bluetooth/stonepeak/init.rc
@@ -2,13 +2,6 @@ on post-fs-data
     # To store BT paired info
     mkdir /data/misc/hcid 0770 bluetooth bluetooth
 
-on boot
-    insmod ${ro.boot.moduleslocation}/iptable_raw.ko
-    insmod ${ro.boot.moduleslocation}/ip6table_raw.ko
-    insmod ${ro.boot.moduleslocation}/6lowpan_iphc.ko
-    insmod ${ro.boot.moduleslocation}/bluetooth.ko
-    insmod ${ro.boot.moduleslocation}/btusb.ko
-
 on post-fs-data
     mkdir /data/misc/dhcp 0770 dhcp system
 

--- a/groups/kernel/android_ia/init.rc
+++ b/groups/kernel/android_ia/init.rc
@@ -1,5 +1,5 @@
-{{#x86_64}}
 on init
+{{#x86_64}}
     symlink /system/lib64/modules /system/lib/modules
 {{/x86_64}}
     #create /etc & /lib folder if they dont exist

--- a/groups/rfkill/true/init.rc
+++ b/groups/rfkill/true/init.rc
@@ -1,5 +1,4 @@
 on boot
-    insmod ${ro.boot.moduleslocation}/rfkill-gpio.ko
     start rfkill-init
 
 service rfkill-init /system/bin/rfkill-init.sh{{{force_disable}}}

--- a/groups/wlan/android_ia/init.rc
+++ b/groups/wlan/android_ia/init.rc
@@ -13,11 +13,6 @@ on post-fs-data
     chmod 0660 /data/misc/wifi/wpa_supplicant.conf
     chown wifi wifi /data/misc/wifi
     chown wifi wifi /data/misc/wifi/wpa_supplicant.conf
-    insmod ${ro.boot.moduleslocation}/compat.ko
-    insmod ${ro.boot.moduleslocation}/cfg80211.ko
-    insmod ${ro.boot.moduleslocation}/mac80211.ko
-    insmod ${ro.boot.moduleslocation}/iwlwifi.ko d0i3_debug=1
-    insmod ${ro.boot.moduleslocation}/iwlmvm.ko always_on=1
     setprop wlan.interface "wlan0"
     setprop wlan.driver.status "ok"
 


### PR DESCRIPTION
These are broken already and we are working on proper support for
ueventd based loading. Lets get rid of them.

Jira: None.
Test: Builds and boots to home screen.

Signed-off-by: Kalyan Kondapally <kalyan.kondapally@intel.com>