### PR TITLE
Enable choice of drm_hwcomposer or hwcomposer

### DIFF
--- a/groups/graphics/android_ia/BoardConfig.mk
+++ b/groups/graphics/android_ia/BoardConfig.mk
@@ -7,7 +7,6 @@ BOARD_GRAPHIC_IS_GEN := true
 BOARD_GPU_DRIVERS := i965
 BOARD_USE_MESA := true
 GRALLOC_DRM := true
-BOARD_USES_DRM_HWCOMPOSER := true
 BOARD_USES_IA_PLANNER := true
 
 # System's VSYNC phase offsets in nanoseconds
@@ -26,3 +25,13 @@ TARGET_USES_HWC2 := true
 {{^hwc2}}
 TARGET_USES_HWC2 := false
 {{/hwc2}}
+
+{{#drmhwc}}
+BOARD_USES_DRM_HWCOMPOSER := true
+BOARD_USES_IA_HWCOMPOSER := false
+{{/drmhwc}}
+
+{{^drmhwc}}
+BOARD_USES_DRM_HWCOMPOSER := false
+BOARD_USES_IA_HWCOMPOSER := true
+{{/drmhwc}}

--- a/groups/graphics/android_ia/product.mk
+++ b/groups/graphics/android_ia/product.mk
@@ -11,14 +11,25 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     device/intel/android_ia/common/graphics/drirc:system/etc/drirc
 
+{{#drmhwc}}
+# DRM HWComposer
+PRODUCT_PACKAGES += \
+    hwcomposer.drm
 
-# HWComposer
+PRODUCT_PROPERTY_OVERRIDES += \
+   hwc.drm.use_overlay_planes=1 \
+   ro.hardware.hwcomposer=drm
+{{/drmhwc}}
+
+{{^drmhwc}}
+# HWComposer IA
 PRODUCT_PACKAGES += \
     hwcomposer.android_ia
 
 PRODUCT_PROPERTY_OVERRIDES += \
    hwc.drm.use_overlay_planes=1 \
    ro.hardware.hwcomposer=android_ia
+{{/drmhwc}}
 
 #Gralloc
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
For testing and bring-up it is helpfull to be able
to run either the drm_hwcomposer and the hwcomposer.
This patch provide the option to choose between any of them.

Jira: None
Test: Build and boot to homescreen for both HWComposers

Signed-off-by: Marta Lofstedt <marta.lofstedt@intel.com>