### PR TITLE
Fix broken Symbolic links generated during build

### DIFF
--- a/groups/kernel/android_ia/AndroidBoard.mk
+++ b/groups/kernel/android_ia/AndroidBoard.mk
@@ -87,7 +87,7 @@ SYMLINKS := $(subst $(FIRMWARES_DIR),$(TARGET_OUT)/etc/firmware,$(filter-out $(F
 
 $(SYMLINKS): FW_PATH := $(FIRMWARES_DIR)
 $(SYMLINKS):
-	@link_to=`readlink $(subst $(TARGET_OUT)/lib/firmware,$(FW_PATH),$@)`; \
+	@link_to=`readlink $(subst $(TARGET_OUT)/etc/firmware,$(FW_PATH),$@)`; \
 	echo "Symlink: $@ -> $$link_to"; \
 	mkdir -p $(@D); ln -sf $$link_to $@
 


### PR DESCRIPTION
Build was generating broken symbolic links for the Firmware files and the same was fixed.

lrwxrwxrwx 1 harishkrupo harishkrupo 75 Jan 24 20:43 bl.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm206/acr/bl.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 73 Jan 24 20:43 bxt_dmc_ver1.bin -> out/target/product/androidia_64/system/etc/firmware/i915/bxt_dmc_ver1.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 73 Jan 24 20:43 dsp_fw_bxtn.bin -> out/target/product/androidia_64/system/etc/firmware/intel/dsp_fw_bxtn.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 72 Jan 24 20:43 dsp_fw_kbl.bin -> out/target/product/androidia_64/system/etc/firmware/intel/dsp_fw_kbl.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 76 Jan 24 20:43 dsp_fw_release.bin -> out/target/product/androidia_64/system/etc/firmware/intel/dsp_fw_release.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 79 Jan 24 20:43 fecs_bl.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gp100/gr/fecs_bl.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 81 Jan 24 20:43 fecs_inst.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm206/gr/fecs_inst.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 80 Jan 24 20:43 gpccs_bl.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gp100/gr/gpccs_bl.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 82 Jan 24 20:43 gpccs_inst.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm206/gr/gpccs_inst.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 73 Jan 24 20:43 kbl_dmc_ver1.bin -> out/target/product/androidia_64/system/etc/firmware/i915/kbl_dmc_ver1.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 63 Jan 24 20:43 qat_mmp.bin -> out/target/product/androidia_64/system/etc/firmware/qat_mmp.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 62 Jan 24 20:43 rt3070.bin -> out/target/product/androidia_64/system/etc/firmware/rt3070.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 62 Jan 24 20:43 rt3090.bin -> out/target/product/androidia_64/system/etc/firmware/rt3090.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 71 Jan 24 20:43 sd8688.bin -> out/target/product/androidia_64/system/etc/firmware/libertas/sd8688.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 78 Jan 24 20:43 sd8688_helper.bin -> out/target/product/androidia_64/system/etc/firmware/libertas/sd8688_helper.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 73 Jan 24 20:43 skl_dmc_ver1.bin -> out/target/product/androidia_64/system/etc/firmware/i915/skl_dmc_ver1.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 73 Jan 24 20:43 skl_guc_ver6.bin -> out/target/product/androidia_64/system/etc/firmware/i915/skl_guc_ver6.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 86 Jan 24 20:43 sw_bundle_init.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm206/gr/sw_bundle_init.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 78 Jan 24 20:43 sw_ctx.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm206/gr/sw_ctx.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 86 Jan 24 20:43 sw_method_init.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm20b/gr/sw_method_init.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 81 Jan 24 20:43 sw_nonctx.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm206/gr/sw_nonctx.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 66 Jan 24 20:43 t4fw.bin -> out/target/product/androidia_64/system/etc/firmware/cxgb4/t4fw.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 66 Jan 24 20:43 t5fw.bin -> out/target/product/androidia_64/system/etc/firmware/cxgb4/t5fw.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 83 Jan 24 20:43 ucode_load.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm204/acr/ucode_load.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 85 Jan 24 20:43 ucode_unload.bin -> out/target/product/androidia_64/system/etc/firmware/nvidia/gm204/acr/ucode_unload.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 82 Jan 24 20:43 wl1271-nvs.bin -> out/target/product/androidia_64/system/etc/firmware/ti-connectivity/wl1271-nvs.bin
lrwxrwxrwx 1 harishkrupo harishkrupo 82 Jan 24 20:43 wl12xx-nvs.bin -> out/target/product/androidia_64/system/etc/firmware/ti-connectivity/wl12xx-nvs.bin


Bug ID: https://01.org/jira/browse/AIA-95
Test: Symbolic links fixed for the Build 

Signed-off-by: Kishore Kadiyala <kishore.kadiyala@intel.com>