### PR TITLE
Use TARGET_COPY_OUT_VENDOR instead of hardcoded /vendor path.

### DIFF
--- a/groups/kernel/android_ia/AndroidBoard.mk
+++ b/groups/kernel/android_ia/AndroidBoard.mk
@@ -15,7 +15,7 @@ KERNEL_NAME := bzImage
 # Set the output for the kernel build products.
 KERNEL_OUT := $(abspath $(TARGET_OUT_INTERMEDIATES)/kernel)
 KERNEL_BIN := $(KERNEL_OUT)/arch/$(TARGET_KERNEL_ARCH)/boot/$(KERNEL_NAME)
-KERNEL_MODULES_INSTALL := $(PRODUCT_OUT)/vendor/lib/modules
+KERNEL_MODULES_INSTALL := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules
 
 KERNELRELEASE = $(shell cat $(KERNEL_OUT)/include/config/kernel.release)
 
@@ -26,7 +26,7 @@ build_kernel := $(MAKE) -C $(TARGET_KERNEL_SRC) \
 		KCFLAGS="$(KERNEL_CFLAGS)" \
 		KAFLAGS="$(KERNEL_AFLAGS)" \
 		$(if $(SHOW_COMMANDS),V=1) \
-		INSTALL_MOD_PATH=$(abspath "$(PRODUCT_OUT)/vendor")
+		INSTALL_MOD_PATH=$(abspath "$(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)")
 
 KERNEL_CONFIG_FILE := device/intel/android_ia/kernel_config/$(TARGET_KERNEL_CONFIG)
 
@@ -49,15 +49,15 @@ $(ALL_EXTRA_MODULES): $(TARGET_OUT_INTERMEDIATES)/kmodule/%: $(PRODUCT_OUT)/kern
 # First copy modules keeping directory hierarchy lib/modules/`uname-r`for libkmod
 # Second, create flat hierarchy for insmod linking to previous hierarchy
 $(KERNEL_MODULES_INSTALL): $(PRODUCT_OUT)/kernel $(ALL_EXTRA_MODULES)
-	$(hide) rm -rf $(PRODUCT_OUT)/vendor/lib/modules
+	$(hide) rm -rf $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules
 	$(build_kernel) modules_install
 	$(hide) for kmod in "$(TARGET_EXTRA_KERNEL_MODULES)" ; do \
 		echo Installing additional kernel module $${kmod} ; \
 		$(subst +,,$(subst $(hide),,$(build_kernel))) M=$(abspath $(TARGET_OUT_INTERMEDIATES))/$${kmod}.kmodule modules_install ; \
 	done
-	$(hide) rm -f $(PRODUCT_OUT)/vendor/lib/modules/*/{build,source}
-	$(hide) mv $(PRODUCT_OUT)/vendor/lib/modules/$(KERNELRELEASE)/* $(PRODUCT_OUT)/vendor/lib/modules
-	$(hide) rm -rf $(PRODUCT_OUT)/vendor/lib/modules/$(KERNELRELEASE)
+	$(hide) rm -f $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules/*/{build,source}
+	$(hide) mv $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules/$(KERNELRELEASE)/* $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules
+	$(hide) rm -rf $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/modules/$(KERNELRELEASE)
 	$(hide) touch $@
 
 # Makes sure any built modules will be included in the system image build.


### PR DESCRIPTION
This makes it easier to disable  the vendor partition, if necessary.

Jira: None
Test: Boot to home screen

Signed-off-by: Michael Goffioul <michael.goffioul@gmail.com>