### PR TITLE
mixins: update fstab for non-sparse image

### DIFF
--- a/groups/android_ia/default/product.mk
+++ b/groups/android_ia/default/product.mk
@@ -25,8 +25,15 @@ $(call inherit-product-if-exists,frameworks/base/data/sounds/AudioPackage6.mk)
 $(call inherit-product-if-exists,vendor/vendor.mk)
 
 #Product Characteristics
+ifeq ($(SPARSE_IMG),true)
+    PRODUCT_COPY_FILES += \
+        $(if $(wildcard $(PRODUCT_DIR)fstab.$(TARGET_PRODUCT)),$(PRODUCT_DIR)fstab.$(TARGET_PRODUCT),$(LOCAL_PATH)/fstab):root/fstab.$(TARGET_PRODUCT)
+else
+    PRODUCT_COPY_FILES += \
+        $(if $(wildcard $(PRODUCT_DIR)fstab.$(TARGET_PRODUCT)),$(PRODUCT_DIR)fstab.$(TARGET_PRODUCT),$(LOCAL_PATH)/fstab_squashfs):root/fstab.$(TARGET_PRODUCT)
+endif
+
 PRODUCT_COPY_FILES += \
-    $(if $(wildcard $(PRODUCT_DIR)fstab.$(TARGET_PRODUCT)),$(PRODUCT_DIR)fstab.$(TARGET_PRODUCT),$(LOCAL_PATH)/fstab):root/fstab.$(TARGET_PRODUCT) \
     $(if $(wildcard $(PRODUCT_DIR)init.$(TARGET_PRODUCT).rc),$(PRODUCT_DIR)init.$(TARGET_PRODUCT).rc,$(LOCAL_PATH)/init.rc):root/init.$(TARGET_PRODUCT).rc \
     $(if $(wildcard $(PRODUCT_DIR)ueventd.$(TARGET_PRODUCT).rc),$(PRODUCT_DIR)ueventd.$(TARGET_PRODUCT).rc,$(LOCAL_PATH)/ueventd.rc):root/ueventd.$(TARGET_PRODUCT).rc \
     $(LOCAL_PATH)/gpt.ini:root/gpt.$(TARGET_PRODUCT).ini \

--- a/mixin-update
+++ b/mixin-update
@@ -34,8 +34,8 @@ None: {
 # These are the set of product configuration files that are modified by mixins.
 # If they are named something else in the actual product directory, the mixin spec
 # file should setup the mapping in the "mapping" section
-_FILE_LIST = ["BoardConfig.mk", "init.rc", "init.recovery.rc", "fstab", "product.mk",
-              "ueventd.rc", "AndroidBoard.mk", "gpt.ini"]
+_FILE_LIST = ["BoardConfig.mk", "init.rc", "init.recovery.rc", "fstab", "fstab_squashfs",
+              "product.mk", "ueventd.rc", "AndroidBoard.mk", "gpt.ini"]
 
 _PRODUCT_SPEC_FN = "mixins.spec"
 _GROUP_SPEC_FN = "mixinfo.spec"


### PR DESCRIPTION
When build system and vendor images with SPARSE_IMG=false, fstab is
also need updated as squashfs.

Jira: None.
Test: tested on Joule

Signed-off-by: Qin Chao <chao.qin@intel.com>