### PR TITLE
[Android-IA] Flashfiles filename format is wrong in artifacts

### DIFF
--- a/groups/boot-arch/android_ia/AndroidBoard.mk
+++ b/groups/boot-arch/android_ia/AndroidBoard.mk
@@ -2,7 +2,11 @@ define generate_flashfiles
 zip -qj $(1) $(2)
 endef
 
+ifneq ($(BUILD_NUMBER),)
+out_flashfiles := $(PRODUCT_OUT)/$(TARGET_PRODUCT)-flashfiles-$(BUILD_NUMBER).zip
+else
 out_flashfiles := $(PRODUCT_OUT)/$(TARGET_PRODUCT).flashfiles.$(TARGET_BUILD_VARIANT).$(USER).zip
+endif
 
 $(PRODUCT_OUT)/efi/installer.cmd:
 	$(ACP) $(TARGET_DEVICE_DIR)/$(@F) $@


### PR DESCRIPTION
Pick correct filename format when CI sets BUILD_NUMBER

JIRA: None
Tests: Compile code successfully, and flashfiles should be generated
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>