### PR TITLE
mixins: fix packages

### DIFF
--- a/groups/audio/android_ia/product.mk
+++ b/groups/audio/android_ia/product.mk
@@ -6,9 +6,8 @@ PRODUCT_PACKAGES_DEBUG += \
 
 # Extended Audio HALs
 PRODUCT_PACKAGES += \
-    audio.r_submix.default \
-    audio.hdmi.android_ia \
     audio.primary.android_ia \
+    audio.r_submix.default \
     audio.usb.default \
     audio_policy.default.so \
     audio_configuration_files


### PR DESCRIPTION
there is no audio.hdmi.android_ia package

Tested on 2:1 SKL platform

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>