### PR TITLE
boot-arch: android_ia: Remove END MIX-IN DEFINITIONS

### DIFF
--- a/groups/audio/android_ia/AndroidBoard.mk
+++ b/groups/audio/android_ia/AndroidBoard.mk
@@ -1,0 +1,2 @@
+# Target specific audio configuration files
+include device/intel/android_ia/common/audio/AndroidBoard.mk

--- a/groups/audio/android_ia/product.mk
+++ b/groups/audio/android_ia/product.mk
@@ -10,8 +10,6 @@ PRODUCT_PACKAGES += \
     audio.hdmi.android_ia \
     audio.primary.android_ia \
     audio.usb.default \
-    audio_policy.default.so
+    audio_policy.default.so \
+    audio_configuration_files
 
-PRODUCT_COPY_FILES += \
-    device/intel/android_ia/common/audio/mixer_paths.xml:system/etc/mixer_paths.xml \
-    device/intel/android_ia/common/audio/audio_policy.conf:system/etc/audio_policy.conf

--- a/groups/boot-arch/android_ia/fstab
+++ b/groups/boot-arch/android_ia/fstab
@@ -17,4 +17,3 @@
 /dev/block/mmcblk1p2	/bootloader2    emmc    defaults                                                    recoveryonly
 /dev/block/mmcblk1p9	/persistent     emmc    defaults                                                    defaults
 /dev/block/mmcblk1p6	/metadata       emmc    defaults                                                    defaults
-# ------------------ END MIX-IN DEFINITIONS ------------------

--- a/groups/boot-arch/android_ia/fstab_byname
+++ b/groups/boot-arch/android_ia/fstab_byname
@@ -19,5 +19,3 @@ attable,forceencrypt=/dev/block/by-name/android_metadata
 /dev/block/by-name/android_persistent   /persistent     emmc    defaults                                                    defaults
 /dev/block/by-name/android_metadata     /metadata       emmc    defaults                                                    defaults
 /dev/block/by-name/android_bldr_utils   /bldr_utils     emmc    defaults                                                    recoveryonly
-
-# ------------------ END MIX-IN DEFINITIONS ------------------


### PR DESCRIPTION
Signed-off-by: Sergio Aguirre <sergio.a.aguirre.rodriguez@intel.com>