### PR TITLE
Switch to XML Audio policy format.

### DIFF
--- a/groups/audio/android_ia/BoardConfig.mk
+++ b/groups/audio/android_ia/BoardConfig.mk
@@ -5,3 +5,5 @@ BOARD_USES_GENERIC_AUDIO ?= false
 #  INTEL_AUDIO_HAL:= audio     -> baseline HAL
 #  INTEL_AUDIO_HAL:= audio_pfw -> PFW-based HAL
 INTEL_AUDIO_HAL := audio
+# Use XML audio policy configuration file
+USE_XML_AUDIO_POLICY_CONF ?= 1


### PR DESCRIPTION
@plbossart, @cc6565 please review

Inside N release we can use XML or legacy .conf format for Audio
policy. This patch is switching to XML format as O release supports
only XML format.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>