### PR TITLE
add INTEL_AUDIO_HAL selection flag default setting.

### DIFF
--- a/groups/audio/android_ia/BoardConfig.mk
+++ b/groups/audio/android_ia/BoardConfig.mk
@@ -1,3 +1,7 @@
 BOARD_USES_ALSA_AUDIO := true
 BOARD_USES_TINY_ALSA_AUDIO := true
 BOARD_USES_GENERIC_AUDIO ?= false
+# Audio HAL selection Flag default setting.
+#  INTEL_AUDIO_HAL:= audio     -> baseline HAL
+#  INTEL_AUDIO_HAL:= audio_pfw -> PFW-based HAL
+INTEL_AUDIO_HAL := audio


### PR DESCRIPTION
@plbossart, @kalyankondapally please review this update for Audio selection.
This request depends on the next pull request:
https://github.com/android-ia/device-androidia-sound/pull/4

In order to be able to switch between baseline and Paramerter
Framework Audio HAL the flag INTEL_AUDIO_HAL needs to be propagated to
Baseline HAL.

Jira: None

Test: Build on latest manifest of the 2 different Audio stacks.

Signed-off-by: Sebastien Guiriec <sebastien.guiriec@intel.com>