### PR TITLE
Swap ordering of partitions data and factory.

### DIFF
--- a/groups/boot-arch/android_ia/fstab
+++ b/groups/boot-arch/android_ia/fstab
@@ -9,7 +9,7 @@
 
 /dev/block/mmcblk1p7	/system         ext4    ro															wait
 /dev/block/mmcblk1p8	/cache          ext4    noatime,nosuid,nodev,errors=panic                           wait,check
-/dev/block/mmcblk1p12	/data           ext4    noatime,nosuid,nodev,discard,noauto_da_alloc,errors=panic   wait,check,formattable,forceencrypt=/dev/block/mmcblk1p6
+/dev/block/mmcblk1p13	/data           ext4    noatime,nosuid,nodev,discard,noauto_da_alloc,errors=panic   wait,check,formattable,forceencrypt=/dev/block/mmcblk1p6
 /dev/block/mmcblk1p3	/boot           emmc    defaults                                                    defaults
 /dev/block/mmcblk1p4	/recovery       emmc    defaults                                                    defaults
 /dev/block/mmcblk1p5	/misc           emmc    defaults                                                    defaults

--- a/groups/boot-arch/android_ia/gpt.ini
+++ b/groups/boot-arch/android_ia/gpt.ini
@@ -1,5 +1,5 @@
 [base]
-partitions = bootloader bootloader2 boot recovery misc metadata system cache persistent vendor config data factory
+partitions = bootloader bootloader2 boot recovery misc metadata system cache persistent vendor config factory data
 
 [partition.bootloader]
 label = android_bootloader

--- a/groups/factory-partition/true/fstab
+++ b/groups/factory-partition/true/fstab
@@ -1,1 +1,1 @@
-/dev/block/mmcblk1p13      /factory        ext4    rw                                         wait
+/dev/block/mmcblk1p12      /factory        ext4    rw                                         wait


### PR DESCRIPTION
Live installer must format data partition last, as it'll eat up the
remaining disk space (there won't be any space left for any partition
after that).

Jira: https://01.org/jira/browse/AIA-402
Test: Live installer succeeds formatting all partitions.

Signed-off-by: Michael Goffioul <michael.goffioul@gmail.com>