### PR TITLE
Add support for stub audio HAL

### DIFF
--- a/groups/audio/android_ia/BoardConfig.mk
+++ b/groups/audio/android_ia/BoardConfig.mk
@@ -1,10 +1,15 @@
 BOARD_USES_ALSA_AUDIO := true
 BOARD_USES_TINY_ALSA_AUDIO := true
 BOARD_USES_GENERIC_AUDIO ?= false
+ifneq ($(BOARD_USES_GENERIC_AUDIO), true)
 # Audio HAL selection Flag default setting.
 #  INTEL_AUDIO_HAL:= audio     -> baseline HAL
 #  INTEL_AUDIO_HAL:= audio_pfw -> PFW-based HAL
 INTEL_AUDIO_HAL := audio
+else
+INTEL_AUDIO_HAL := stub
+endif
+
 # Use XML audio policy configuration file
 USE_XML_AUDIO_POLICY_CONF ?= 1
 # Use configurable audio policy

--- a/groups/audio/android_ia/product.mk
+++ b/groups/audio/android_ia/product.mk
@@ -4,9 +4,16 @@ PRODUCT_PACKAGES_DEBUG += \
          tinyplay \
          tinycap
 
+ifneq ($(BOARD_USES_GENERIC_AUDIO), true)
+PRODUCT_PACKAGES += \
+    audio.primary.android_ia
+else
+PRODUCT_PACKAGES += \
+    audio.primary.default
+endif
+
 # Extended Audio HALs
 PRODUCT_PACKAGES += \
-    audio.primary.android_ia \
     audio.r_submix.default \
     audio.usb.default \
     audio_policy.default.so \


### PR DESCRIPTION
Don't include audio.primary.android_ia when there is no hardware attached

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>