### PR TITLE
clean-up PRODUCT_PACKAGES for audio

### DIFF
--- a/groups/audio/android_ia/product.mk
+++ b/groups/audio/android_ia/product.mk
@@ -4,14 +4,6 @@ PRODUCT_PACKAGES_DEBUG += \
          tinyplay \
          tinycap
 
-ifneq ($(BOARD_USES_GENERIC_AUDIO), true)
-PRODUCT_PACKAGES += \
-    audio.primary.android_ia
-else
-PRODUCT_PACKAGES += \
-    audio.primary.default
-endif
-
 # Extended Audio HALs
 PRODUCT_PACKAGES += \
     audio.r_submix.default \


### PR DESCRIPTION
the relevant modules will be handled as dependencies of the
audio_configuration_files module, no need to have any code here

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>