### PR TITLE
Include WallpaperPicker for android IA

### DIFF
--- a/groups/android_ia/default/product.mk
+++ b/groups/android_ia/default/product.mk
@@ -147,6 +147,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     LiveWallpapers \
     LiveWallpapersPicker \
+    WallpaperPicker \
     NotePad \
     Provision \
     camera.android_ia \


### PR DESCRIPTION
Lack of WallpaperPicker will cause Launcher crash
JIRA: AIA-419
Test:
    Step 1 Connect joule to HDMI Cable
    Step 2 Long tap on Homescreen
    Step 3 tap on "WALLPAPERS"
    Step 4 Observe

The Launcher should not crash.

Signed-off-by: xianhaox <xianhaox.qing@intel.com>