### PR TITLE
Due to IA don't support GPS, need to delete the statement that suppor…

### DIFF
--- a/groups/android_ia/default/product.mk
+++ b/groups/android_ia/default/product.mk
@@ -64,7 +64,6 @@ PRODUCT_COPY_FILES += \
 # Gps
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.location.xml:system/etc/permissions/android.hardware.location.xml \
-    frameworks/native/data/etc/android.hardware.location.gps.xml:system/etc/permissions/android.hardware.location.gps.xml \
 
 # Touch
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
…t GPS features

Jira: none
Test:
run cts -m CtsLocationTestCases -t android.location.cts.LocationManagerTest#testGetProvider
run cts -m CtsLocationTestCases -t android.location.cts.LocationManagerTest#testGetProviders

Signed-off-by: Yue, VincentX <vincentx.yue@intel.com>