### PR TITLE
Change the correct location of sepolicy for crashlogd

### DIFF
--- a/groups/debug-crashlogd/true/product.mk
+++ b/groups/debug-crashlogd/true/product.mk
@@ -9,7 +9,7 @@ endif
 
 ifeq ($(MIXIN_DEBUG_LOGS),true)
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += persist.crashlogd.data_quota=50
-BOARD_SEPOLICY_DIRS += device/intel/sepolicy/crashlogd
+BOARD_SEPOLICY_DIRS += device/intel/android_ia/sepolicy/crashlogd
 
 CRASHLOGD_LOGS_PATH := "/data/logs"
 CRASHLOGD_APLOG := true


### PR DESCRIPTION
Change the correct location of sepolicy for crashlogd

Jira: https://jira01.devtools.intel.com/browse/OAM-53653
Test: Tests on KBL_NUC

Signed-off-by: Shen, ZhitaX zhitax.shen@intel.com
  
  
  