### PR TITLE
Storage: Add support for 'Quota' userdata feature

### DIFF
--- a/groups/boot-arch/android_ia/fstab
+++ b/groups/boot-arch/android_ia/fstab
@@ -9,7 +9,7 @@
 
 /dev/block/by-name/android_system   	/system         ext4    ro															wait
 /dev/block/by-name/android_cache		/cache          ext4    noatime,nosuid,nodev,errors=panic                           wait,check
-/dev/block/by-name/android_data         /data           ext4    noatime,nosuid,nodev,discard,noauto_da_alloc,errors=panic   wait,check,formattable,forceencrypt=/dev/block/by-name/android_metadata
+/dev/block/by-name/android_data         /data           ext4    noatime,nosuid,nodev,discard,noauto_da_alloc,errors=panic   wait,check,formattable,forceencrypt=/dev/block/by-name/android_metadata,quota
 /dev/block/by-name/android_boot         /boot           emmc    defaults                                                    defaults
 /dev/block/by-name/android_recovery     /recovery       emmc    defaults                                                    defaults
 /dev/block/by-name/android_misc         /misc           emmc    defaults                                                    defaults


### PR DESCRIPTION
Added support for 'Quota' feature to avoid
Storage security related CTS issue.
Quota will improve system stability as well as
giving better experience for the user.
Android 8.0 recommends this feature on the
userdata partition.

Jira:None
Test:None
Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>